### PR TITLE
feat: add --prefer-ssh option for mirror command; enhance preflight credential checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), using
 - **mirror command**: Clone/update repositories from groups/orgs
   - Auto-detect provider from URL (e.g., `https://github.com/zsoftly`)
   - Clone to `$HOME/<org>/` by default
-  - HTTPS-first, SSH-fallback for git operations
+  - HTTPS-first, SSH-fallback for git operations (or `--prefer-ssh` for SSH-first)
   - Parallel processing (configurable, default: 4)
   - Skip archived repositories
   - Skip stale repos (not updated in N months, default: 12)
@@ -21,6 +21,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), using
   - Organization and user repos (GitHub)
   - Display repo sizes during operations
   - Colored output (git-style)
+  - Smart update: stashes changes, switches to default branch, pulls latest
 - **Preflight credential validation**: Checks git credentials before cloning
   - Tests HTTPS/SSH access with `git ls-remote`
   - Fails fast with actionable fix suggestions

--- a/cmd/ztigit/main.go
+++ b/cmd/ztigit/main.go
@@ -83,6 +83,7 @@ var (
 	mirrorVerbose       bool
 	mirrorMaxAge        int
 	mirrorSkipPreflight bool
+	mirrorPreferSSH     bool
 )
 
 func init() {
@@ -92,6 +93,7 @@ func init() {
 	mirrorCmd.Flags().BoolVarP(&mirrorVerbose, "verbose", "v", false, "Verbose output")
 	mirrorCmd.Flags().IntVar(&mirrorMaxAge, "max-age", 12, "Skip repos not updated in this many months (0 = no limit)")
 	mirrorCmd.Flags().BoolVar(&mirrorSkipPreflight, "skip-preflight", false, "Skip git credential validation before cloning")
+	mirrorCmd.Flags().BoolVar(&mirrorPreferSSH, "prefer-ssh", false, "Use SSH URLs instead of HTTPS for git operations")
 	rootCmd.AddCommand(mirrorCmd)
 }
 
@@ -173,6 +175,7 @@ func runMirror(cmd *cobra.Command, args []string) error {
 		Verbose:       mirrorVerbose,
 		MaxAgeMonths:  mirrorMaxAge,
 		SkipPreflight: mirrorSkipPreflight,
+		PreferSSH:     mirrorPreferSSH,
 	}
 
 	if opts.BaseDir == "" {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,6 +74,7 @@ ztigit mirror <url-or-org> [options]
 | `--dir`, `-d`      | No       | Base directory (default: `$HOME/<org>`)                        |
 | `--max-age`        | No       | Skip repos not updated in N months (default: 12, 0 = no limit) |
 | `--parallel`       | No       | Parallel operations (default: 4)                               |
+| `--prefer-ssh`     | No       | Use SSH URLs instead of HTTPS for git operations               |
 | `--skip-preflight` | No       | Skip git credential validation before cloning                  |
 | `--verbose`, `-v`  | No       | Verbose output                                                 |
 
@@ -81,7 +82,8 @@ ztigit mirror <url-or-org> [options]
 
 - API: Set `GITHUB_TOKEN` or `GITLAB_TOKEN` environment variable
 - Git: Uses your existing git credentials (HTTPS credential helper or SSH keys)
-- Clone attempts HTTPS first, falls back to SSH if HTTPS fails
+- Default: HTTPS first, falls back to SSH if HTTPS fails
+- Use `--prefer-ssh` to try SSH first (recommended if you have SSH keys configured)
 
 **GitLab**: Groups including subgroups are supported.
 
@@ -105,6 +107,9 @@ ztigit mirror zsoftly -p github --max-age 0
 
 # Custom directory, verbose
 ztigit mirror https://github.com/zsoftly -d ~/projects -v
+
+# Use SSH instead of HTTPS
+ztigit mirror https://github.com/zsoftly --prefer-ssh
 ```
 
 Output:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--prefer-ssh` flag to mirror command to prioritize SSH URLs over HTTPS for git operations.
  * Enhanced mirror update flow to intelligently stash local changes, switch to the default branch, and pull the latest updates.

* **Documentation**
  * Updated command documentation with `--prefer-ssh` flag usage examples and authentication guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->