### PR TITLE
feat: update installation instructions for macOS; add missing binary download commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-linux-
 chmod +x ztigit
 sudo mv ztigit /usr/local/bin/
 
+# macOS (Intel)
+curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-darwin-amd64 -o ztigit
+chmod +x ztigit
+sudo mv ztigit /usr/local/bin/
+
 # macOS (Apple Silicon)
 curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-darwin-arm64 -o ztigit
 chmod +x ztigit

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,13 +16,20 @@ Pre-built binaries available for:
 ### Linux/macOS
 
 ```bash
-# Download (replace with your platform)
+# Linux (amd64)
 curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-linux-amd64 -o ztigit
 
-# Make executable
-chmod +x ztigit
+# Linux (arm64)
+curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-linux-arm64 -o ztigit
 
-# Move to PATH
+# macOS (Intel)
+curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-darwin-amd64 -o ztigit
+
+# macOS (Apple Silicon)
+curl -L https://github.com/zsoftly/ztigit/releases/latest/download/ztigit-darwin-arm64 -o ztigit
+
+# Make executable and install
+chmod +x ztigit
 sudo mv ztigit /usr/local/bin/
 
 # Verify


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded installation instructions with explicit platform-specific download commands for Linux (amd64, arm64) and macOS (Intel and Apple Silicon architectures).
  * Updated README and installation documentation with clear setup steps for all supported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->