### PR TITLE
feat: update changelog and rename --prefer-ssh to --ssh; enhance auto detection of git credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to ztigit will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), using
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-12-19
+
+### Changed
+
+- **Auto-detect git credentials**: Preflight automatically switches to SSH if HTTPS is unavailable
+- **Renamed `--prefer-ssh` to `--ssh`**: Simpler flag name to skip HTTPS test and use SSH directly
+
+### Fixed
+
+- **Installation docs**: Added macOS Intel (darwin-amd64) to download instructions
+- **Clarified docs**: Updated authentication documentation to accurately describe auto-detection
+  behavior
+
+**Full Changelog**: https://github.com/zsoftly/ztigit/compare/0.0.1...0.0.2
+
+---
+
 ## [0.0.1] - 2025-12-18
 
 ### Added
@@ -13,7 +30,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), using
 - **mirror command**: Clone/update repositories from groups/orgs
   - Auto-detect provider from URL (e.g., `https://github.com/zsoftly`)
   - Clone to `$HOME/<org>/` by default
-  - HTTPS-first, SSH-fallback for git operations (or `--prefer-ssh` for SSH-first)
+  - Auto-detects working git credentials (HTTPS or SSH), or use `--ssh` to force SSH
   - Parallel processing (configurable, default: 4)
   - Skip archived repositories
   - Skip stale repos (not updated in N months, default: 12)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # Cross-platform build targets for GitLab/GitHub CLI tool
 
 BINARY_NAME=ztigit
-VERSION?=0.0.1
+# Auto-detect version from git tags (e.g., "0.0.2" or "0.0.2-3-g1a2b3c4" for dev builds)
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_DIR=bin
 CMD_DIR=cmd/ztigit
 

--- a/cmd/ztigit/main.go
+++ b/cmd/ztigit/main.go
@@ -26,7 +26,7 @@ var (
 )
 
 var (
-	version = "0.0.1"
+	version = "dev" // overridden at build time via ldflags
 	cfg     *config.Config
 )
 
@@ -83,7 +83,7 @@ var (
 	mirrorVerbose       bool
 	mirrorMaxAge        int
 	mirrorSkipPreflight bool
-	mirrorPreferSSH     bool
+	mirrorSSH           bool
 )
 
 func init() {
@@ -93,7 +93,7 @@ func init() {
 	mirrorCmd.Flags().BoolVarP(&mirrorVerbose, "verbose", "v", false, "Verbose output")
 	mirrorCmd.Flags().IntVar(&mirrorMaxAge, "max-age", 12, "Skip repos not updated in this many months (0 = no limit)")
 	mirrorCmd.Flags().BoolVar(&mirrorSkipPreflight, "skip-preflight", false, "Skip git credential validation before cloning")
-	mirrorCmd.Flags().BoolVar(&mirrorPreferSSH, "prefer-ssh", false, "Use SSH URLs instead of HTTPS for git operations")
+	mirrorCmd.Flags().BoolVar(&mirrorSSH, "ssh", false, "Use SSH URLs instead of HTTPS for git operations")
 	rootCmd.AddCommand(mirrorCmd)
 }
 
@@ -175,7 +175,7 @@ func runMirror(cmd *cobra.Command, args []string) error {
 		Verbose:       mirrorVerbose,
 		MaxAgeMonths:  mirrorMaxAge,
 		SkipPreflight: mirrorSkipPreflight,
-		PreferSSH:     mirrorPreferSSH,
+		SSH:           mirrorSSH,
 	}
 
 	if opts.BaseDir == "" {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,7 +74,7 @@ ztigit mirror <url-or-org> [options]
 | `--dir`, `-d`      | No       | Base directory (default: `$HOME/<org>`)                        |
 | `--max-age`        | No       | Skip repos not updated in N months (default: 12, 0 = no limit) |
 | `--parallel`       | No       | Parallel operations (default: 4)                               |
-| `--prefer-ssh`     | No       | Use SSH URLs instead of HTTPS for git operations               |
+| `--ssh`            | No       | Use SSH URLs instead of HTTPS for git operations               |
 | `--skip-preflight` | No       | Skip git credential validation before cloning                  |
 | `--verbose`, `-v`  | No       | Verbose output                                                 |
 
@@ -82,8 +82,8 @@ ztigit mirror <url-or-org> [options]
 
 - API: Set `GITHUB_TOKEN` or `GITLAB_TOKEN` environment variable
 - Git: Uses your existing git credentials (HTTPS credential helper or SSH keys)
-- Default: HTTPS first, falls back to SSH if HTTPS fails
-- Use `--prefer-ssh` to try SSH first (recommended if you have SSH keys configured)
+- Default: Auto-detects working method (tests HTTPS first, falls back to SSH)
+- Use `--ssh` to skip HTTPS test and use SSH directly
 
 **GitLab**: Groups including subgroups are supported.
 
@@ -109,7 +109,7 @@ ztigit mirror zsoftly -p github --max-age 0
 ztigit mirror https://github.com/zsoftly -d ~/projects -v
 
 # Use SSH instead of HTTPS
-ztigit mirror https://github.com/zsoftly --prefer-ssh
+ztigit mirror https://github.com/zsoftly --ssh
 ```
 
 Output:

--- a/internal/mirror/preflight.go
+++ b/internal/mirror/preflight.go
@@ -30,7 +30,7 @@ type credentialMethod struct {
 // Returns the preferred method (https or ssh) that works, or an error if neither works
 func (m *Mirror) Preflight(ctx context.Context, repos []provider.Repository) (*PreflightResult, error) {
 	if len(repos) == 0 {
-		if m.options.PreferSSH {
+		if m.options.SSH {
 			return &PreflightResult{Method: "ssh"}, nil
 		}
 		return &PreflightResult{Method: "https"}, nil
@@ -41,7 +41,7 @@ func (m *Mirror) Preflight(ctx context.Context, repos []provider.Repository) (*P
 
 	// Build ordered list of methods to test
 	var methods []credentialMethod
-	if m.options.PreferSSH {
+	if m.options.SSH {
 		methods = []credentialMethod{
 			{name: "ssh", url: testRepo.SSHUrl},
 			{name: "https", url: testRepo.CloneURL},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-detects working git credentials, testing HTTPS first and falling back to SSH when unavailable.
  * Renamed CLI flag `--prefer-ssh` to `--ssh` to skip HTTPS testing and use SSH directly.

* **Bug Fixes**
  * Added installation instructions for macOS Intel systems.
  * Clarified authentication documentation to describe credential auto-detection behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->